### PR TITLE
[Bugfix] Wrong Identifiers

### DIFF
--- a/livelyPropertyListener.js
+++ b/livelyPropertyListener.js
@@ -23,7 +23,7 @@ function livelyPropertyListener(name, val)
             break;
 
         case "showActiveImageFilename":
-            controller.showActiveImageFilename();
+            slideshow.showActiveImageFilename();
             break;
 
         // Ripple

--- a/slideshowController.js
+++ b/slideshowController.js
@@ -62,12 +62,7 @@ class SlideshowController {
 
     toggle(interval = 60000)
     {
-        if (this.#interval === null)
-        {
-            this.startSlideshow(interval);
-            return;
-        }
-        this.stopSlideshow();
+        if (this.#isEnabled) { this.disable(); } else { this.enable(interval); }
     }
 
     add(image)


### PR DESCRIPTION
Incorrect identifiers resulted in the following functionalities having no effect
*  `showActiveImageFilename` command in Lively interop
*  `toggleSlideshow()`

This PR fixes these two bugs.