### PR TITLE
[Feature] Smooth noise/brightness transition

### DIFF
--- a/src/modules/controllerBase.ts
+++ b/src/modules/controllerBase.ts
@@ -21,7 +21,7 @@ export abstract class ControllerBase
 
     public toggle(): void
     {
-        this._isEnabled = !this._isEnabled;
+        if (this.isEnabled) { this.disable(); } else { this.enable(); }
     }
 
     receive(parameters: string[]): void {

--- a/src/modules/noise/noise.css
+++ b/src/modules/noise/noise.css
@@ -1,3 +1,8 @@
+:root {
+    --noise_opacity: 0;
+    --noise_brightness: 1;
+}
+
 .noise_base {
     position: absolute;
     min-width: 100vw;
@@ -7,8 +12,10 @@
 
 #noise_noise {
     background-image: url("noise.png");
+    opacity: var(--noise_opacity);
 }
 
-.noise_hidden {
-    opacity: 0 !important;
+#noise_brightness {
+    background-color: black;
+    opacity: calc(1 - var(--noise_brightness));
 }

--- a/src/modules/noise/noiseController.ts
+++ b/src/modules/noise/noiseController.ts
@@ -7,7 +7,6 @@ export class NoiseController extends ControllerBase {
     private readonly baseTag = `${this.Identifier}_base`;
     private readonly noiseTag = `${this.Identifier}_noise`;
     private readonly brightnessTag = `${this.Identifier}_brightness`;
-    private readonly hiddenTag = `${this.Identifier}_hidden`;
 
     private _canvasElement: HTMLElement;
     private _noiseElement: HTMLElement = document.createElement("div");
@@ -17,8 +16,8 @@ export class NoiseController extends ControllerBase {
     public get noise(): number { return this._noise; }
     public set noise(value: number)
     { 
-        this._noise = value;        
-        this._brightnessElement.style.opacity = "" + this.noise;
+        this._noise = value;
+        this.update(this.noise, this.brightness);
     }
 
     private _brightness : number;
@@ -26,7 +25,7 @@ export class NoiseController extends ControllerBase {
     public set brightness(value: number)
     { 
         this._brightness = value;
-        this._brightnessElement.style.backgroundColor = `rgba(0,0,0,${1-this.brightness})`;
+        this.update(this.noise, this.brightness);
     }
 
     constructor(canvas: HTMLElement, noise: number, brightness: number)
@@ -37,33 +36,35 @@ export class NoiseController extends ControllerBase {
         this.brightness = brightness;
 
         this._brightnessElement.classList.add(this.baseTag);
-        this._brightnessElement.classList.add(this.hiddenTag);
         this._brightnessElement.id = this.brightnessTag;
         this._canvasElement.appendChild(this._brightnessElement);
 
         this._noiseElement.classList.add(this.baseTag);
-        this._noiseElement.classList.add(this.hiddenTag);
         this._noiseElement.id = this.noiseTag;
         this._canvasElement.appendChild(this._noiseElement);
     }
 
     enable(): void
     {
-        super.enable();        
-        this._brightnessElement.classList.remove(this.hiddenTag);
-        this._noiseElement.classList.remove(this.hiddenTag);
+        super.enable();
+        this.update(this.noise, this.brightness);
     }
 
     disable(): void
     {
         super.disable();
-        this._brightnessElement.classList.add(this.hiddenTag);
-        this._noiseElement.classList.add(this.hiddenTag);
+        this.update(0, 1);
     }
 
     toggle(): void
     {
-        if (this.isEnabled) { this.disable(); } else { this.enable(); }
+        super.toggle();
+    }
+
+    update(noise: number, brightness: number)
+    {
+        document.documentElement.style.setProperty(`--${this.noiseTag}`, "" + noise);   
+        document.documentElement.style.setProperty(`--${this.brightnessTag}`, "" + brightness);  
     }
 
     receive(parameters: string[]): void {


### PR DESCRIPTION
This PR uses CSS variables to allow smooth transition between noise/brightness levels even when set dynamically through `NoiseController.noise = value` and `NoiseController.brightness = value`.