### PR TITLE
[Bugfix] NoiseController._brightnessElement not displayed

### DIFF
--- a/src/modules/noise/noiseController.ts
+++ b/src/modules/noise/noiseController.ts
@@ -43,10 +43,11 @@ export class NoiseController extends ControllerBase {
         if (brightness !== undefined)
         {
             this.brightness = brightness;
-            this._brightnessElement.classList.add(this.baseTag);
-            this._brightnessElement.id = this.brightnessTag;
-            this._canvasElement.appendChild(this._brightnessElement);
         }
+        
+        this._brightnessElement.classList.add(this.baseTag);
+        this._brightnessElement.id = this.brightnessTag;
+        this._canvasElement.appendChild(this._brightnessElement);
 
         this._noiseElement.classList.add(this.baseTag);
         this._noiseElement.id = this.noiseTag;

--- a/src/modules/noise/noiseController.ts
+++ b/src/modules/noise/noiseController.ts
@@ -30,6 +30,7 @@ export class NoiseController extends ControllerBase {
      */
     public set brightness(value: number)
     { 
+        console.warn("NoiseController.Brightness is deprecated. Use BackdropFilterController instead.")
         this._brightness = value;
         this.update(this.noise, this.brightness);
     }


### PR DESCRIPTION
This occurred due to a mis-scoped if condition that prevented the brightness element from being appended to the HTML document.